### PR TITLE
CloseStream is called when DATA+END_STREAM is written

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Http2WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Http2WriteScheduler.java
@@ -148,6 +148,7 @@ public class Http2WriteScheduler implements WriteScheduler
         if (direct && !stream.endStreamSent)
         {
             stream.endStreamSent = true;
+            connection.closeStream(stream);
             return writer.dataEos(streamId);
         }
         return true;
@@ -179,6 +180,7 @@ public class Http2WriteScheduler implements WriteScheduler
                 if (entry.stream.endStream && !entry.stream.endStreamSent)
                 {
                     entry.stream.endStreamSent = true;
+                    connection.closeStream(entry.stream);
                     writer.dataEos(entry.stream.http2StreamId);
                 }
             }
@@ -209,6 +211,7 @@ public class Http2WriteScheduler implements WriteScheduler
             if (stream.endStream && !stream.endStreamSent)
             {
                 stream.endStreamSent = true;
+                connection.closeStream(stream);
                 writer.dataEos(streamId);
             }
         }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Settings.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Settings.java
@@ -19,7 +19,7 @@ class Settings
 {
     static final int DEFAULT_HEADER_TABLE_SIZE = 4096;
     static final boolean DEFAULT_ENABLE_PUSH = true;
-    static final int DEFAULT_MAX_CONCURRENT_STREAMS = 100;
+    static final int DEFAULT_MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE;
     static final int DEFAULT_INITIAL_WINDOW_SIZE = 65_535;
     static final int DEFAULT_MAX_FRAME_SIZE = 16_384;
 
@@ -29,4 +29,13 @@ class Settings
     int initialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
     int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
     long maxHeaderListSize;
+
+    Settings(int maxConcurrentStreams)
+    {
+        this.maxConcurrentStreams = maxConcurrentStreams;
+    }
+
+    Settings()
+    {
+    }
 }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/SourceInputStreamFactory.java
@@ -269,7 +269,7 @@ public final class SourceInputStreamFactory
             this.throttleState = this::throttleNextWindow;
             sourceOutputEstId = supplyStreamId.getAsLong();
             http2Streams = new Int2ObjectHashMap<>();
-            localSettings = new Settings();
+            localSettings = new Settings(100);
             remoteSettings = new Settings();
             decodeContext = new HpackContext(localSettings.headerTableSize, false);
             encodeContext = new HpackContext(remoteSettings.headerTableSize, true);
@@ -977,7 +977,7 @@ public final class SourceInputStreamFactory
             }
         }
 
-        private void closeStream(Http2Stream stream)
+        void closeStream(Http2Stream stream)
         {
             if (stream.isClientInitiated())
             {
@@ -1396,7 +1396,7 @@ public final class SourceInputStreamFactory
                     source.routableName(), OUTPUT_ESTABLISHED);
 
             correlateNew.accept(targetId, correlation);
-            newTarget.addThrottle(targetId, this::handleThrottle);
+            // TODO if upstream resets this stream, how do we know that ?
         }
 
         private Http2Stream newStream(int http2StreamId, State state, Route route)
@@ -1876,6 +1876,7 @@ public final class SourceInputStreamFactory
             resetRO.wrap(buffer, index, index + length);
             httpWriteScheduler.onReset();
             releaseReplyBuffer();
+            connection.closeStream(this);
             //source.doReset(sourceId);
         }
 


### PR DESCRIPTION
CloseStream is called when DATA+END_STREAM is written. That removes the
stream from http2Streams map, also reduces the no of concurrent connections
- remote settings get unlimited concurrent streams by default
- local settings get recommended 100 concurrent streams