### PR TITLE
Reducing the number DATA frames written to the client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <jmh.version>1.12</jmh.version>
 
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
-    <nukleus.version>0.3</nukleus.version>
+    <nukleus.version>0.6</nukleus.version>
     <nukleus.http2.spec.version>0.12</nukleus.http2.spec.version>
     <reaktor.test.version>0.5</reaktor.test.version>
     <reaktor.version>0.3</reaktor.version>
@@ -112,6 +112,11 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.reaktivity</groupId>
+      <artifactId>nukleus-tcp</artifactId>
+      <version>0.6</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Http2WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Http2WriteScheduler.java
@@ -185,6 +185,7 @@ public class Http2WriteScheduler implements WriteScheduler
                 }
             }
         }
+        writer.onWindow();
 
         if (entryCount == 0 && end && !endSent)
         {
@@ -203,6 +204,7 @@ public class Http2WriteScheduler implements WriteScheduler
         {
             write(entry);
         }
+        writer.onWindow();
 
         if (!buffered(stream))
         {
@@ -229,14 +231,14 @@ public class Http2WriteScheduler implements WriteScheduler
         DirectBuffer read = entry.stream.acquireReplyBuffer(this::read);
         int offset1 = entry.stream.replyBuffer.readOffset();
         int read1 = entry.stream.replyBuffer.read(entry.length);
-        writer.data(entry.stream.http2StreamId, read, offset1, read1, entry.progress);
+        writer.data(entry.stream.http2StreamId, read, offset1, read1, entry.progress, false);
 
         if (read1 != entry.length)
         {
             int offset2 = entry.stream.replyBuffer.readOffset();
             int read2 = entry.stream.replyBuffer.read(entry.length - read1);
             assert read1 + read2 == entry.length;
-            writer.data(entry.stream.http2StreamId, read, offset2, read2, entry.progress);
+            writer.data(entry.stream.http2StreamId, read, offset2, read2, entry.progress, false);
         }
 
         entry.adjustWindows();

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Http2WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/Http2WriteScheduler.java
@@ -311,7 +311,10 @@ public class Http2WriteScheduler implements WriteScheduler
 
         boolean fits()
         {
-            int min = Math.min(Math.min(length, (int) connection.http2OutWindow), (int) stream.http2OutWindow);
+            // limit by http2 windows, peer's max frame size
+            int min = Math.min((int) connection.http2OutWindow, (int) stream.http2OutWindow);
+            min = Math.min(min, length);
+            min = Math.min(min, connection.remoteSettings.maxFrameSize);
             if (min > 0)
             {
                 int remaining = length - min;

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/SourceInputStreamFactory.java
@@ -245,7 +245,7 @@ public final class SourceInputStreamFactory
 
         private boolean goaway;
         private Settings localSettings;
-        private Settings remoteSettings;
+        Settings remoteSettings;
         private boolean expectContinuation;
         private int expectContinuationStreamId;
         private boolean expectDynamicTableSizeUpdate = true;


### PR DESCRIPTION
Reducing the number DATA frames written to the client
- The nuklei frames are not directly written to the target. They are written to
  a temporary buffer and the whole buffer is written to target

TODO: removing the data structure in NukleusWriteScheduler