### PR TITLE
Removing  Connection specific header fields in response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.6</nukleus.version>
-    <nukleus.http2.spec.version>0.13</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.14</nukleus.http2.spec.version>
     <reaktor.test.version>0.5</reaktor.test.version>
     <reaktor.version>0.3</reaktor.version>
     <k3po.nukleus.ext.version>0.5</k3po.nukleus.ext.version>

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/HpackContext.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/HpackContext.java
@@ -102,6 +102,9 @@ public class HpackContext
     public static final DirectBuffer CONNECTION = new UnsafeBuffer("connection".getBytes(UTF_8));
     public static final DirectBuffer TE = new UnsafeBuffer("te".getBytes(UTF_8));
     public static final DirectBuffer TRAILERS = new UnsafeBuffer("trailers".getBytes(UTF_8));
+    public static final DirectBuffer KEEP_ALIVE = new UnsafeBuffer("keep-alive".getBytes(UTF_8));
+    public static final DirectBuffer PROXY_CONNECTION = new UnsafeBuffer("proxy-connection".getBytes(UTF_8));
+    public static final DirectBuffer UPGRADE = new UnsafeBuffer("upgrade".getBytes(UTF_8));
 
     // Dynamic table. Entries are added at the end (since it is in reverse order,
     // need to calculate the index accordingly)

--- a/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/MessageFormatIT.java
@@ -75,4 +75,14 @@ public class MessageFormatIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+            "${route}/server/controller",
+            "${spec}/connection.headers/client",
+            "${nukleus}/connection.headers/server" })
+    public void connectionHeaders() throws Exception
+    {
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
Removing headers nominated by Connection header field in response (also
other headers like Transfer-Encoding, Proxy-Connection, Upgrade etc)

Issue:
https://github.com/reaktivity/nukleus-http2.java/issues/29

spec test:
https://github.com/reaktivity/nukleus-http2.spec/pull/21