### PR TITLE
Simplified flow control 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.6</nukleus.version>
-    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.15</nukleus.http2.spec.version>
     <reaktor.test.version>0.5</reaktor.test.version>
     <reaktor.version>0.3</reaktor.version>
     <k3po.nukleus.ext.version>0.5</k3po.nukleus.ext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,6 @@
       <version>${jmh.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.reaktivity</groupId>
-      <artifactId>nukleus-tcp</artifactId>
-      <version>develop-SNAPSHOT</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.6</nukleus.version>
-    <nukleus.http2.spec.version>0.14</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
     <reaktor.test.version>0.5</reaktor.test.version>
     <reaktor.version>0.3</reaktor.version>
     <k3po.nukleus.ext.version>0.5</k3po.nukleus.ext.version>
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>org.reaktivity</groupId>
       <artifactId>nukleus-tcp</artifactId>
-      <version>0.6</version>
+      <version>develop-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/Target.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/Target.java
@@ -339,6 +339,8 @@ public final class Target implements Nukleus
             int payloadOffset,
             int payloadLength)
     {
+        assert streamId != 0;
+
         return (buffer, offset, limit) ->
                 http2DataRW.wrap(buffer, offset, limit)
                            .streamId(streamId)
@@ -349,6 +351,8 @@ public final class Target implements Nukleus
 
     public Flyweight.Builder.Visitor visitDataEos(int streamId)
     {
+        assert streamId != 0;
+
         return (buffer, offset, limit) ->
                 http2DataRW.wrap(buffer, offset, limit)
                       .streamId(streamId)
@@ -371,6 +375,21 @@ public final class Target implements Nukleus
                               .sizeof();
     }
 
+    public Flyweight.Builder.Visitor visitHeaders(
+            int streamId,
+            DirectBuffer srcBuffer,
+            int srcOffset,
+            int srcLength)
+    {
+        return (buffer, offset, limit) ->
+                http2HeadersRW.wrap(buffer, offset, limit)
+                              .streamId(streamId)
+                              .endHeaders()
+                              .payload(srcBuffer, srcOffset, srcLength)
+                              .build()
+                              .sizeof();
+    }
+
     public Flyweight.Builder.Visitor visitPushPromise(
             int streamId,
             int promisedStreamId,
@@ -383,6 +402,23 @@ public final class Target implements Nukleus
                              .promisedStreamId(promisedStreamId)
                              .endHeaders()
                              .headers(b -> builder.accept(headers, b))
+                             .build()
+                             .sizeof();
+    }
+
+    public Flyweight.Builder.Visitor visitPushPromise(
+            int streamId,
+            int promisedStreamId,
+            DirectBuffer srcBuffer,
+            int srcOffset,
+            int srcLength)
+    {
+        return (buffer, offset, limit) ->
+                pushPromiseRW.wrap(buffer, offset, limit)
+                             .streamId(streamId)
+                             .promisedStreamId(promisedStreamId)
+                             .endHeaders()
+                             .payload(srcBuffer, srcOffset, srcLength)
                              .build()
                              .sizeof();
     }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/CircularDirectBuffer.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/CircularDirectBuffer.java
@@ -71,6 +71,15 @@ class CircularDirectBuffer
         return true;
     }
 
+    int writeContiguous(MutableDirectBuffer dstBuffer, DirectBuffer srcBuffer, int srcIndex, int length)
+    {
+        int part = (start <= end) ? Math.min(length, capacity - end) : Math.min(length, start - end);
+        dstBuffer.putBytes(end, srcBuffer, srcIndex, part);
+        count += part;
+        end = (end + part) % capacity;
+        return part;
+    }
+
     int read(int length)
     {
         if (length > count)

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/NukleusWriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/NukleusWriteScheduler.java
@@ -66,6 +66,8 @@ class NukleusWriteScheduler
         slab.buffer(accumulatedSlot, this::accumulated);
         int length = visitor.visit(accumulated, accumulatedOffset, lengthGuess);
         accumulatedOffset += length;
+
+        assert accumulatedOffset < 65536;       // DataFW's length is 2 bytes
         return length;
     }
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/NukleusWriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/NukleusWriteScheduler.java
@@ -15,45 +15,25 @@
  */
 package org.reaktivity.nukleus.http2.internal.routable.stream;
 
-import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.reaktivity.nukleus.http2.internal.routable.Target;
 import org.reaktivity.nukleus.http2.internal.types.Flyweight;
-import org.reaktivity.nukleus.http2.internal.types.HttpHeaderFW;
-import org.reaktivity.nukleus.http2.internal.types.ListFW;
-import org.reaktivity.nukleus.http2.internal.types.stream.Http2ErrorCode;
-import org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType;
-
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.function.Consumer;
 
 import static org.reaktivity.nukleus.http2.internal.routable.stream.Slab.NO_SLOT;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.DATA;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.GO_AWAY;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.HEADERS;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.PING;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.PUSH_PROMISE;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.RST_STREAM;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.SETTINGS;
-import static org.reaktivity.nukleus.http2.internal.types.stream.Http2FrameType.WINDOW_UPDATE;
 
-class NukleusWriteScheduler implements WriteScheduler
+class NukleusWriteScheduler
 {
-    private final MutableDirectBuffer reply = new UnsafeBuffer(new byte[0]);
     private final MutableDirectBuffer accumulated = new UnsafeBuffer(new byte[0]);
+    private int accumulatedSlot = NO_SLOT;
+
     private final SourceInputStreamFactory.SourceInputStream connection;
     private final Target target;
     private final long targetId;
     private final long sourceOutputEstId;
-    private final Deque<ConnectionEntry> replyQueue;
 
-    private int replySlot = NO_SLOT;
-    private CircularEntryBuffer replyBuffer;
     private Slab slab;
-    private boolean end;
-    private boolean endSent;
+    private int accumulatedOffset;
 
     NukleusWriteScheduler(
             SourceInputStreamFactory.SourceInputStream connection,
@@ -67,375 +47,52 @@ class NukleusWriteScheduler implements WriteScheduler
         this.slab = slab;
         this.target = target;
         this.targetId = targetId;
-        this.replyQueue = new LinkedList<>();
     }
 
-    public boolean http2(
-            int streamId,
+    int http2Frame(
             int lengthGuess,
-            Http2FrameType type,
-            Flyweight.Builder.Visitor visitor,
-            Consumer<Integer> progress)
+            Flyweight.Builder.Visitor visitor)
     {
-        return http2(streamId, lengthGuess, type, visitor, progress, true);
-    }
-
-    public boolean http2(
-            int streamId,
-            int lengthGuess,
-            Http2FrameType type,
-            Flyweight.Builder.Visitor visitor,
-            Consumer<Integer> progress,
-            boolean flush)
-    {
-        acquireReplyBuffer();    // TODO return value
-        CircularEntryBuffer cb = replyBuffer;
-        int offset = cb.writeOffset(lengthGuess);
-        if (offset != -1)
-        {
-            int length = visitor.visit(reply, offset, lengthGuess);
-            cb.write(offset, length);
-            ConnectionEntry entry = new ConnectionEntry(streamId, offset, length, type, progress);
-            replyQueue.add(entry);
-            if (flush)
-            {
-                onWindow();                     // check if partial write is possible
-            }
-        }
-        return offset != -1;
-    }
-
-    @Override
-    public boolean windowUpdate(int streamId, int update)
-    {
-        Flyweight.Builder.Visitor window = target.visitWindowUpdate(streamId, update);
-        int sizeof = 9 + 4;             // +9 for HTTP2 framing, +4 window size increment
-        return http2(streamId, sizeof, WINDOW_UPDATE, window, null);
-    }
-
-    @Override
-    public boolean pingAck(DirectBuffer buffer, int offset, int length)
-    {
-        int sizeof = 9 + 8;             // +9 for HTTP2 framing, +8 for a ping
-        Flyweight.Builder.Visitor ping = target.visitPingAck(buffer, offset, length);
-        return http2(0, sizeof, PING, ping, null);
-    }
-
-    @Override
-    public boolean goaway(int lastStreamId, Http2ErrorCode errorCode)
-    {
-        int sizeof = 9 + 8;             // +9 for HTTP2 framing, +8 for goaway payload
-        Flyweight.Builder.Visitor goaway = target.visitGoaway(lastStreamId, errorCode);
-        return http2(0, sizeof, GO_AWAY, goaway, null);
-    }
-
-    @Override
-    public boolean rst(int streamId, Http2ErrorCode errorCode)
-    {
-        int sizeof = 9 + 4;             // +9 for HTTP2 framing, +4 for RST_STREAM payload
-        Flyweight.Builder.Visitor rst = target.visitRst(streamId, errorCode);
-        return http2(streamId, sizeof, RST_STREAM, rst, null);
-    }
-
-    @Override
-    public boolean settings(int maxConcurrentStreams)
-    {
-        int sizeof = 9 + 6;             // +9 for HTTP2 framing, +6 for a setting
-        Flyweight.Builder.Visitor settings = target.visitSettings(maxConcurrentStreams);
-        return http2(0, sizeof, SETTINGS, settings, null);
-    }
-
-    @Override
-    public boolean settingsAck()
-    {
-        int sizeof = 9;                 // +9 for HTTP2 framing
-        Flyweight.Builder.Visitor settings = target.visitSettingsAck();
-        return http2(0, sizeof, SETTINGS, settings, null);
-    }
-
-    @Override
-    public boolean headers(int streamId, ListFW<HttpHeaderFW> headers)
-    {
-        int sizeof = 9 + headersLength(headers);    // +9 for HTTP2 framing
-        Flyweight.Builder.Visitor data = target.visitHeaders(streamId, headers, connection::mapHeaders);
-        return http2(streamId, sizeof, HEADERS, data, null);
-    }
-
-    @Override
-    public boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers,
-                               Consumer<Integer> progress)
-    {
-        int sizeof = 9 + 4 + headersLength(headers);    // +9 for HTTP2 framing, +4 for promised stream id
-        Flyweight.Builder.Visitor data = target.visitPushPromise(streamId, promisedStreamId, headers, connection::mapPushPromize);
-        return http2(streamId, sizeof, PUSH_PROMISE, data, null);
-    }
-
-    @Override
-    public boolean data(int streamId, DirectBuffer buffer, int offset, int length, Consumer<Integer> progress)
-    {
-        return data(streamId, buffer, offset, length, progress, true);
-    }
-
-    public boolean data(int streamId, DirectBuffer buffer, int offset, int length, Consumer<Integer> progress, boolean flush)
-    {
-        assert length > 0;
-        int sizeof = 9 + length;    // +9 for HTTP2 framing
-        Flyweight.Builder.Visitor data = target.visitData(streamId, buffer, offset, length);
-        return http2(streamId, sizeof, DATA, data, progress, flush);
-    }
-
-    @Override
-    public void doEnd()
-    {
-        end = true;
-        if (!buffered() && !endSent)
-        {
-            endSent = true;
-            target.doEnd(targetId);
-        }
-    }
-
-    // Since it is not encoding, this gives an approximate length of header block
-    private int headersLength(ListFW<HttpHeaderFW> headers)
-    {
-        int[] length = new int[1];
-        headers.forEach(x -> length[0] += x.name().sizeof() + x.value().sizeof() + 4);
-        return length[0];
-    }
-
-    @Override
-    public boolean dataEos(int streamId)
-    {
-        int sizeof = 9;    // +9 for HTTP2 framing
-        Flyweight.Builder.Visitor data = target.visitDataEos(streamId);
-        return http2(streamId, sizeof, DATA, data, null);
-    }
-
-    @Override
-    public void onWindow()
-    {
-        if (connection.outWindow < connection.outWindowThreshold)
-        {
-            // Instead of sending small updates, wait until a bigger window accumulates
-            return;
-        }
-
-        int accumulatedSlot = NO_SLOT;
-        try
+        if (accumulatedSlot == NO_SLOT)
         {
             accumulatedSlot = slab.acquire(sourceOutputEstId);
-            if (accumulatedSlot == NO_SLOT)
-            {
-                connection.cleanConnection();
-                return;
-            }
-            MutableDirectBuffer accumulatedBuffer = slab.buffer(accumulatedSlot, this::accumulated);
-
-            ConnectionEntry entry;
-            int offset = 0;
-            while ((entry = pop()) != null)
-            {
-                acquireReplyBuffer();
-                accumulatedBuffer.putBytes(offset, reply, entry.offset, entry.length);
-                offset += entry.length;
-
-                if (entry.progress != null)
-                {
-                    entry.progress.accept(entry.payload);
-                }
-            }
-
-            if (offset > 0)
-            {
-                target.doData(targetId, accumulatedBuffer, 0, offset);
-            }
-
-
-            if (!buffered())
-            {
-                releaseReplyBuffer();
-
-                if (end && !endSent)
-                {
-                    endSent = true;
-                    target.doEnd(targetId);
-                }
-            }
         }
-        finally
+
+        if (accumulatedSlot == NO_SLOT)
         {
-            if (accumulatedSlot != NO_SLOT)
-            {
-                slab.release(accumulatedSlot);
-            }
+            connection.cleanConnection();
+            return -1;
         }
+        slab.buffer(accumulatedSlot, this::accumulated);
+        int length = visitor.visit(accumulated, accumulatedOffset, lengthGuess);
+        accumulatedOffset += length;
+        return length;
     }
 
-    private boolean buffered()
+    void doEnd()
     {
-        return !replyQueue.isEmpty();
+        target.doEnd(targetId);
     }
 
-    private ConnectionEntry pop()
+    void flush()
     {
-        if (buffered())
+        if (accumulatedOffset > 0)
         {
-            ConnectionEntry entry = replyQueue.peek();
-            if (entry != null && entry.fits())
-            {
-                entry = replyQueue.poll();
-                replyBuffer.read(entry.offset, entry.length);
-                entry.adjustWindows();
-                return entry;
-            }
+            target.doData(targetId, accumulated, 0, accumulatedOffset);
+            accumulatedOffset = 0;
         }
 
-        return null;
-    }
-
-    @Override
-    public void onHttp2Window()
-    {
-        throw new IllegalStateException();
-    }
-
-    @Override
-    public void onHttp2Window(int streamId)
-    {
-        throw new IllegalStateException();
-    }
-
-    private MutableDirectBuffer reply(MutableDirectBuffer buffer)
-    {
-        reply.wrap(buffer.addressOffset(), buffer.capacity());
-        return reply;
+        if (accumulatedSlot != NO_SLOT)
+        {
+            slab.release(accumulatedSlot);
+            accumulatedSlot = NO_SLOT;
+        }
     }
 
     private MutableDirectBuffer accumulated(MutableDirectBuffer buffer)
     {
         accumulated.wrap(buffer.addressOffset(), buffer.capacity());
         return accumulated;
-    }
-
-    /*
-     * @return true if there is a buffer
-     *         false if all slots are taken
-     */
-    private MutableDirectBuffer acquireReplyBuffer()
-    {
-        if (replySlot == NO_SLOT)
-        {
-            replySlot = slab.acquire(sourceOutputEstId);
-            if (replySlot != NO_SLOT)
-            {
-                int capacity = slab.buffer(replySlot).capacity();
-                replyBuffer = new CircularEntryBuffer(capacity);
-            }
-        }
-        return replySlot != NO_SLOT ? slab.buffer(replySlot, this::reply) : null;
-    }
-
-    private void releaseReplyBuffer()
-    {
-        if (replySlot != NO_SLOT)
-        {
-            slab.release(replySlot);
-            replySlot = NO_SLOT;
-            replyBuffer = null;
-        }
-    }
-
-    private class ConnectionEntry
-    {
-        final int streamId;
-        final int offset;
-        final int length;
-        final int framing;
-        final int payload;
-        final Http2FrameType type;
-        private final Consumer<Integer> progress;
-
-        ConnectionEntry(
-                int streamId,
-                int offset,
-                int length,
-                Http2FrameType type,
-                Consumer<Integer> progress)
-        {
-            this(streamId, offset, length, 9, length - 9, type, progress);
-        }
-
-        ConnectionEntry(
-                int streamId,
-                int offset,
-                int length,
-                int framing,
-                int payload,
-                Http2FrameType type,
-                Consumer<Integer> progress)
-        {
-            assert framing >= 0;
-            assert payload >= 0;
-            assert framing + payload == length;
-
-            this.streamId = streamId;
-            this.offset = offset;
-            this.length = length;
-            this.framing = framing;
-            this.payload = payload;
-            this.type = type;
-            this.progress = progress;
-        }
-
-        boolean fits()
-        {
-            int entry1Length = Math.min(length, connection.outWindow);
-            if (entry1Length > 0)
-            {
-                int entry2Length = length - entry1Length;
-                if (entry2Length > 0)
-                {
-                    // Splits this entry into two entries
-                    replyQueue.poll();
-
-                    // Construct such that first entry fits under connection.outWindow
-                    int entry1Framing = Math.min(framing, connection.outWindow);
-                    int entry1Payload = entry1Length - entry1Framing;
-                    assert entry1Framing >= 0;
-                    assert entry1Payload >= 0;
-                    ConnectionEntry entry1 = new ConnectionEntry(streamId, offset, entry1Length,
-                            entry1Framing, entry1Payload, type, progress);
-
-                    // Construct second entry with the remaining
-                    int entry2Framing = framing - entry1Framing;
-                    int entry2Payload = entry2Length - entry2Framing;
-                    assert entry2Framing >= 0;
-                    assert entry2Payload >= 0;
-                    ConnectionEntry entry2 = new ConnectionEntry(streamId, offset + entry1Length, entry2Length,
-                            entry2Framing, entry2Payload, type, progress);
-
-                    assert entry1Length + entry2Length == length;
-                    assert entry1Framing + entry2Framing == framing;
-                    assert entry1Payload + entry2Payload == payload;
-
-                    replyQueue.addFirst(entry2);
-                    replyQueue.addFirst(entry1);
-                }
-            }
-
-            return entry1Length > 0;
-        }
-
-        void adjustWindows()
-        {
-            connection.outWindow -= length;
-        }
-
-        public String toString()
-        {
-            return String.format("streamId=%d type=%s offset=%d length=%d", streamId, type, offset, length);
-        }
-
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/SourceInputStreamFactory.java
@@ -1856,7 +1856,8 @@ public final class SourceInputStreamFactory
 
         private void onData()
         {
-            httpWriteScheduler.onData(http2DataRO);
+            boolean written = httpWriteScheduler.onData(http2DataRO);
+            assert written;
         }
 
         private void onThrottle(

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/routable/stream/WriteScheduler.java
@@ -21,7 +21,7 @@ import org.reaktivity.nukleus.http2.internal.types.HttpHeaderFW;
 import org.reaktivity.nukleus.http2.internal.types.ListFW;
 import org.reaktivity.nukleus.http2.internal.types.stream.Http2ErrorCode;
 
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 
 /*
  * Writes HTTP2 frames to a connection. There are multiple streams multiplexed in
@@ -50,9 +50,9 @@ public interface WriteScheduler
 
     boolean headers(int streamId, ListFW<HttpHeaderFW> headers);
 
-    boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers, Consumer<Integer> progress);
+    boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers, IntConsumer progress);
 
-    boolean data(int streamId, DirectBuffer buffer, int offset, int length, Consumer<Integer> progress);
+    boolean data(int streamId, DirectBuffer buffer, int offset, int length, IntConsumer progress);
 
     boolean dataEos(int streamId);
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2DataFW.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2DataFW.java
@@ -132,17 +132,6 @@ public class Http2DataFW extends Http2FrameFW
             return this;
         }
 
-        public Builder payload(DirectBuffer buffer)
-        {
-            return payload(buffer, 0, buffer.capacity());
-        }
-
-        public Builder payload(DirectBuffer payload, int offset, int length)
-        {
-            buffer().putBytes(offset() + PAYLOAD_OFFSET, payload, offset, length);
-            payloadLength(length);
-            return this;
-        }
     }
 }
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2FrameFW.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2FrameFW.java
@@ -146,6 +146,18 @@ public class Http2FrameFW extends Flyweight
             return (B) this;
         }
 
+        public final B payload(DirectBuffer buffer)
+        {
+            return payload(buffer, 0, buffer.capacity());
+        }
+
+        public B payload(DirectBuffer payload, int offset, int length)
+        {
+            buffer().putBytes(offset() + PAYLOAD_OFFSET, payload, offset, length);
+            payloadLength(length);
+            return (B) this;
+        }
+
         protected final B payloadLength(int length)
         {
             buffer().putShort(offset() + LENGTH_OFFSET, (short) ((length & 0x00_FF_FF_00) >>> 8), BIG_ENDIAN);

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2PingFW.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2PingFW.java
@@ -123,11 +123,7 @@ public class Http2PingFW extends Http2FrameFW
             return this;
         }
 
-        public Http2PingFW.Builder payload(DirectBuffer payload)
-        {
-            return payload(payload, 0, payload.capacity());
-        }
-
+        @Override
         public Http2PingFW.Builder payload(DirectBuffer payload, int offset, int length)
         {
             if (length != 8)
@@ -135,7 +131,7 @@ public class Http2PingFW extends Http2FrameFW
                 throw new IllegalArgumentException(String.format("Invalid PING frame length = %d (must be 8)", length));
             }
 
-            buffer().putBytes(offset() + PAYLOAD_OFFSET, payload, offset, 8);
+            super.payload(payload, offset, length);
             return this;
         }
 

--- a/src/test/java/org/reaktivity/nukleus/http2/internal/routable/stream/CircularDirectBufferTest.java
+++ b/src/test/java/org/reaktivity/nukleus/http2/internal/routable/stream/CircularDirectBufferTest.java
@@ -67,4 +67,45 @@ public class CircularDirectBufferTest
         return part1 + part2;
     }
 
+    @Test
+    public void writeContiguous()
+    {
+        int capacity = 100;
+        MutableDirectBuffer src = new UnsafeBuffer(new byte[capacity]);
+        MutableDirectBuffer dst = new UnsafeBuffer(new byte[capacity]);
+
+        // will test all boundaries with start of the buffer at i
+        for(int i=0; i < 100; i++)
+        {
+            CircularDirectBuffer cb = new CircularDirectBuffer(capacity);
+            assertEquals(i, cb.writeContiguous(dst, src, 0, i));
+            assertEquals(i, read(cb, i));
+
+            // now start is at i
+            assertEquals(20, write(cb, dst, src, 0, 20));
+            assertEquals(30, write(cb, dst, src, 0, 30));
+            assertEquals(40, write(cb, dst, src, 0, 40));
+            assertEquals(10, write(cb, dst, src, 0, 10));
+
+            assertEquals(5, read(cb, 5));
+            assertEquals(20, read(cb, 20));
+            assertEquals(15, read(cb, 15));
+            assertEquals(30, read(cb, 30));
+            assertEquals(30, read(cb, 30));
+        }
+    }
+
+    private int write(CircularDirectBuffer cb, MutableDirectBuffer dst, MutableDirectBuffer src, int index, int length)
+    {
+        int part1 = cb.writeContiguous(dst, src, index, length);
+        int part2 = 0;
+
+        if (part1 != length)
+        {
+            part2 = cb.writeContiguous(dst, src, index, length-part1);
+        }
+        System.out.println("part1="+part1+" part2="+part2);
+        return part1 + part2;
+    }
+
 }


### PR DESCRIPTION
Flow control is reimplemented differently:
- Http2WriteScheduler writes to nukleus layer only when all windows are met
- NukleusWriteScheduler collects all the HTTP2 encoded frames. flush() flushes them
  in one nukleus DATA frame
- Completely simplifies NukleusWriteScheduler