### PR TITLE
reset the extension while building the END flyweight 

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
@@ -81,6 +81,7 @@ class Http2Writer
     {
         EndFW end = endRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                          .streamId(targetId)
+                         .extension(e -> e.reset())
                          .build();
 
         target.accept(end.typeId(), end.buffer(), end.offset(), end.sizeof());

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
@@ -109,6 +109,7 @@ class HttpWriter
     {
         EndFW end = endRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                          .streamId(targetId)
+                         .extension(e -> e.reset())
                          .build();
 
         target.accept(end.typeId(), end.buffer(), end.offset(), end.sizeof());


### PR DESCRIPTION
reset the extension while building END flyweight (otherwise, a big END frame is written).