### PR TITLE
Handling when there is no route

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.20</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>0.19</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
@@ -204,7 +204,7 @@ public class Http2WriteScheduler implements WriteScheduler
     }
 
     @Override
-    public boolean headers(int streamId, ListFW<HttpHeaderFW> headers)
+    public boolean headers(int streamId, boolean endStream, ListFW<HttpHeaderFW> headers)
     {
         int sizeof = 9 + headersLength(headers);    // +9 for HTTP2 framing
         Http2FrameType type = HEADERS;
@@ -213,7 +213,7 @@ public class Http2WriteScheduler implements WriteScheduler
 
         if (!buffered(streamId) && sizeof <= connection.outWindow)
         {
-            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, headers, connection::mapHeaders);
+            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, endStream, headers, connection::mapHeaders);
             http2(stream, type, sizeof, visitor, progress);
         }
         else
@@ -222,7 +222,7 @@ public class Http2WriteScheduler implements WriteScheduler
             connection.factory.blockRW.wrap(copy, 0, copy.capacity());
             connection.mapHeaders(headers, connection.factory.blockRW);
 
-            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, copy, 0, copy.capacity());
+            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, endStream, copy, 0, copy.capacity());
             HeadersEntry entry = new HeadersEntry(stream, streamId, sizeof, type, visitor, progress);
             addEntry(entry);
         }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
@@ -204,7 +204,7 @@ public class Http2WriteScheduler implements WriteScheduler
     }
 
     @Override
-    public boolean headers(int streamId, boolean endStream, ListFW<HttpHeaderFW> headers)
+    public boolean headers(int streamId, byte flags, ListFW<HttpHeaderFW> headers)
     {
         int sizeof = 9 + headersLength(headers);    // +9 for HTTP2 framing
         Http2FrameType type = HEADERS;
@@ -213,7 +213,7 @@ public class Http2WriteScheduler implements WriteScheduler
 
         if (!buffered(streamId) && sizeof <= connection.outWindow)
         {
-            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, endStream, headers, connection::mapHeaders);
+            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, flags, headers, connection::mapHeaders);
             http2(stream, type, sizeof, visitor, progress);
         }
         else
@@ -222,7 +222,7 @@ public class Http2WriteScheduler implements WriteScheduler
             connection.factory.blockRW.wrap(copy, 0, copy.capacity());
             connection.mapHeaders(headers, connection.factory.blockRW);
 
-            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, endStream, copy, 0, copy.capacity());
+            Flyweight.Builder.Visitor visitor = http2Writer.visitHeaders(streamId, flags, copy, 0, copy.capacity());
             HeadersEntry entry = new HeadersEntry(stream, streamId, sizeof, type, visitor, progress);
             addEntry(entry);
         }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
@@ -184,49 +184,38 @@ class Http2Writer
 
     Flyweight.Builder.Visitor visitHeaders(
             int streamId,
-            boolean endStream,
+            byte flags,
             ListFW<HttpHeaderFW> headers,
             BiConsumer<ListFW<HttpHeaderFW>, HpackHeaderBlockFW.Builder> builder)
     {
+        byte headersFlags = (byte) (flags | Http2Flags.END_HEADERS);
+
         return (buffer, offset, limit) ->
-        {
-            byte flags = Http2Flags.END_HEADERS;
-            if (endStream)
-            {
-                flags |= Http2Flags.END_STREAM;
-            }
-            return http2HeadersRW.wrap(buffer, offset, limit)
-                          .streamId(streamId)
-                          .flags(flags)
-                          .headers(b -> builder.accept(headers, b))
-                          .build()
-                          .sizeof();
-        };
+                http2HeadersRW.wrap(buffer, offset, limit)
+                              .streamId(streamId)
+                              .flags(headersFlags)
+                              .headers(b -> builder.accept(headers, b))
+                              .build()
+                              .sizeof();
     }
 
     Flyweight.Builder.Visitor visitHeaders(
             int streamId,
-            boolean endStream,
+            byte flags,
             DirectBuffer srcBuffer,
             int srcOffset,
             int srcLength)
     {
         assert streamId != 0;
 
+        byte headersFlags = (byte) (flags | Http2Flags.END_HEADERS);
         return (buffer, offset, limit) ->
-        {
-            byte flags = Http2Flags.END_HEADERS;
-            if (endStream)
-            {
-                flags |= Http2Flags.END_STREAM;
-            }
-            return http2HeadersRW.wrap(buffer, offset, limit)
-                          .streamId(streamId)
-                          .flags(flags)
-                          .payload(srcBuffer, srcOffset, srcLength)
-                          .build()
-                          .sizeof();
-        };
+                http2HeadersRW.wrap(buffer, offset, limit)
+                              .streamId(streamId)
+                              .flags(headersFlags)
+                              .payload(srcBuffer, srcOffset, srcLength)
+                              .build()
+                              .sizeof();
     }
 
     Flyweight.Builder.Visitor visitPushPromise(

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
@@ -23,6 +23,8 @@ import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.function.MessageConsumer;
 import org.reaktivity.nukleus.function.MessageFunction;
 import org.reaktivity.nukleus.function.MessagePredicate;
+import org.reaktivity.nukleus.http2.internal.types.HttpHeaderFW;
+import org.reaktivity.nukleus.http2.internal.types.ListFW;
 import org.reaktivity.nukleus.http2.internal.types.control.HttpRouteExFW;
 import org.reaktivity.nukleus.http2.internal.types.control.RouteFW;
 import org.reaktivity.nukleus.http2.internal.types.stream.AbortFW;
@@ -81,6 +83,8 @@ public final class ServerStreamFactory implements StreamFactory
     final Http2PriorityFW priorityRO = new Http2PriorityFW();
     final UnsafeBuffer scratch = new UnsafeBuffer(new byte[8192]);  // TODO
     final HttpBeginExFW.Builder httpBeginExRW = new HttpBeginExFW.Builder();
+    final ListFW.Builder<HttpHeaderFW.Builder, HttpHeaderFW> headersRW =
+            new ListFW.Builder<>(new HttpHeaderFW.Builder(), new HttpHeaderFW());
     final DirectBuffer nameRO = new UnsafeBuffer(new byte[0]);
     final DirectBuffer valueRO = new UnsafeBuffer(new byte[0]);
     final HttpBeginExFW beginExRO = new HttpBeginExFW();
@@ -105,6 +109,9 @@ public final class ServerStreamFactory implements StreamFactory
     final LongSupplier supplyCorrelationId;
     final HttpWriter httpWriter;
     final Http2Writer http2Writer;
+
+    // Buf to build HTTP error status code header
+    final MutableDirectBuffer errorBuf = new UnsafeBuffer(new byte[64]);
 
 
     final Long2ObjectHashMap<Correlation> correlations;

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
@@ -48,7 +48,7 @@ public interface WriteScheduler
 
     boolean settingsAck();
 
-    boolean headers(int streamId, boolean endStream, ListFW<HttpHeaderFW> headers);
+    boolean headers(int streamId, byte flags, ListFW<HttpHeaderFW> headers);
 
     boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers, IntConsumer progress);
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
@@ -48,7 +48,7 @@ public interface WriteScheduler
 
     boolean settingsAck();
 
-    boolean headers(int streamId, ListFW<HttpHeaderFW> headers);
+    boolean headers(int streamId, boolean endStream, ListFW<HttpHeaderFW> headers);
 
     boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers, IntConsumer progress);
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2Flags.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2Flags.java
@@ -17,6 +17,7 @@ package org.reaktivity.nukleus.http2.internal.types.stream;
 
 public interface Http2Flags
 {
+    byte NONE = 0x0;
     byte END_STREAM = 0x01;
     byte ACK = 0x01;
     byte END_HEADERS = 0x04;

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2FrameFW.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2FrameFW.java
@@ -140,6 +140,14 @@ public class Http2FrameFW extends Flyweight
             return (B) this;
         }
 
+        public final B flags(byte f)
+        {
+            byte flags = buffer().getByte(offset() + FLAGS_OFFSET);
+            flags |= f;
+            buffer().putByte(offset() + FLAGS_OFFSET, flags);
+            return (B) this;
+        }
+
         public final B streamId(int streamId)
         {
             buffer().putInt(offset() + STREAM_ID_OFFSET, streamId, BIG_ENDIAN);

--- a/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/ConnectionManagementIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/ConnectionManagementIT.java
@@ -71,6 +71,15 @@ public class ConnectionManagementIT
     @Test
     @Specification({
             "${route}/server/controller",
+            "${spec}/http.unknown.authority/client" })
+    public void httpUnknownAuthority() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+            "${route}/server/controller",
             "${spec}/http.post.exchange/client",
             "${nukleus}/http.post.exchange/server" })
     public void httpPostExchange() throws Exception


### PR DESCRIPTION
If there is not route found for a request, sends 404 status code on the the corresponding HTTP2
stream.