### PR TITLE
Aligning the http2 stream window with http window

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.21</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>0.21</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.22</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>0.20</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -115,6 +115,7 @@ final class Http2Connection
     private int maxPushPromiseStreamId;
 
     private boolean goaway;
+    Settings initialSettings;
     Settings localSettings;
     Settings remoteSettings;
     private boolean expectContinuation;
@@ -141,7 +142,7 @@ final class Http2Connection
         this.wrapRoute = wrapRoute;
         sourceOutputEstId = networkReplyId;
         http2Streams = new Int2ObjectHashMap<>();
-        localSettings = new Settings(100);
+        localSettings = new Settings();
         remoteSettings = new Settings();
         decodeContext = new HpackContext(localSettings.headerTableSize, false);
         encodeContext = new HpackContext(remoteSettings.headerTableSize, true);
@@ -189,8 +190,8 @@ final class Http2Connection
         this.sourceRef = beginRO.sourceRef();
         this.sourceName = beginRO.source().asString();
         this.decoderState = this::decodePreface;
-
-        writeScheduler.settings(localSettings.maxConcurrentStreams);
+        initialSettings = new Settings(100, 0);
+        writeScheduler.settings(initialSettings.maxConcurrentStreams, initialSettings.initialWindowSize);
     }
 
     void handleData(DataFW dataRO)
@@ -900,6 +901,17 @@ final class Http2Connection
         {
             factory.settingsRO.accept(this::doSetting);
             writeScheduler.settingsAck();
+        }
+        else
+        {
+            int update =  initialSettings.initialWindowSize - localSettings.initialWindowSize;
+            for(Http2Stream http2Stream: http2Streams.values())
+            {
+                http2Stream.http2InWindow += update;           // http2InWindow can become negative
+            }
+
+            // now that peer acked our initial settings, can use them as our local settings
+            localSettings = initialSettings;
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
@@ -155,11 +155,11 @@ public class Http2WriteScheduler implements WriteScheduler
     }
 
     @Override
-    public boolean settings(int maxConcurrentStreams)
+    public boolean settings(int maxConcurrentStreams, int initialWindowSize)
     {
         int streamId = 0;
         int sizeof = 9 + 6;             // +9 for HTTP2 framing, +6 for a setting
-        Flyweight.Builder.Visitor settings = http2Writer.visitSettings(maxConcurrentStreams);
+        Flyweight.Builder.Visitor settings = http2Writer.visitSettings(maxConcurrentStreams, initialWindowSize);
         Http2FrameType type = SETTINGS;
         IntConsumer progress = NOOP;
         Http2Stream stream = null;

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
@@ -92,11 +92,13 @@ class Http2Writer
     }
 
     Flyweight.Builder.Visitor visitSettings(
-            int maxConcurrentStreams)
+            int maxConcurrentStreams,
+            int initialWindowSize)
     {
         return (buffer, offset, limit) ->
                 settingsRW.wrap(buffer, offset, limit)
                           .maxConcurrentStreams(maxConcurrentStreams)
+                          .initialWindowSize(initialWindowSize)
                           .build()
                           .sizeof();
     }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Settings.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Settings.java
@@ -30,9 +30,10 @@ class Settings
     int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
     long maxHeaderListSize;
 
-    Settings(int maxConcurrentStreams)
+    Settings(int maxConcurrentStreams, int initialWindowSize)
     {
         this.maxConcurrentStreams = maxConcurrentStreams;
+        this.initialWindowSize = initialWindowSize;
     }
 
     Settings()

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
@@ -44,7 +44,7 @@ public interface WriteScheduler
 
     boolean rst(int streamId, Http2ErrorCode errorCode);
 
-    boolean settings(int maxConcurrentStreams);
+    boolean settings(int maxConcurrentStreams, int initialWindowSize);
 
     boolean settingsAck();
 


### PR DESCRIPTION
Aligning the http2 stream window with http window. This allows no buffers to be used

on the request path (except for partial http2 frames)
- http2 stream initial window is set 0 by sending SETTINGS_INITIAL_WINDOW_SIZE = 0
- http2 stream window is aligned with corresponding http stream window
- http2 connection window is set as the sum of all http stream windows