### PR TITLE
The order for PUSH_PROMISE streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.23</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
     <jmh.version>1.12</jmh.version>
     <jmock.version>2.6.0</jmock.version>
 
-    <k3po.version>3.0.0-alpha-77</k3po.version>
-    <k3po.nukleus.ext.version>0.7.2</k3po.nukleus.ext.version>
+    <k3po.version>3.0.0-alpha-79</k3po.version>
+    <k3po.nukleus.ext.version>0.8.2</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.10</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>0.22</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
@@ -240,9 +240,9 @@ class Http2Writer
     Flyweight.Builder.Visitor visitPushPromise(
             int streamId,
             int promisedStreamId,
-            DirectBuffer srcBuffer,
-            int srcOffset,
-            int srcLength)
+            DirectBuffer headersBuffer,
+            int headersOffset,
+            int headersLength)
     {
         assert streamId != 0;
 
@@ -251,7 +251,7 @@ class Http2Writer
                              .streamId(streamId)
                              .promisedStreamId(promisedStreamId)
                              .endHeaders()
-                             .payload(srcBuffer, srcOffset, srcLength)
+                             .headers(headersBuffer, headersOffset, headersLength)
                              .build()
                              .sizeof();
     }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2PushPromiseFW.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/Http2PushPromiseFW.java
@@ -182,6 +182,13 @@ public class Http2PushPromiseFW extends Http2FrameFW
             return this;
         }
 
+        public Builder headers(DirectBuffer headersBuf, int headersOffset, int headersLength)
+        {
+            buffer().putBytes(offset() + PAYLOAD_OFFSET + 4, headersBuf, headersOffset, headersLength);
+            payloadLength(headersLength + 4);
+            return this;
+        }
+
     }
 }
 

--- a/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/MessageFormatIT.java
@@ -97,4 +97,14 @@ public class MessageFormatIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+            "${route}/server/controller",
+            "${spec}/stream.id.order/client",
+            "${nukleus}/stream.id.order/server" })
+    public void streamIdOrder() throws Exception
+    {
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
The order for PUSH_PROMISE streams is maintained by adding them to connection queue.
The same thing is done for all the other frames (except DATA frames).