### PR TITLE
Uptook new nukleus maven plugin version and the required http.spec ch…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
     <k3po.version>3.0.0-alpha-79</k3po.version>
     <k3po.nukleus.ext.version>0.8.2</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.10</nukleus.plugin.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>0.23</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <k3po.version>3.0.0-alpha-79</k3po.version>
     <k3po.nukleus.ext.version>0.8.2</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.plugin.version>0.11</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
     <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <nukleus.plugin.version>0.12</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.24</nukleus.http2.spec.version>
     <reaktor.version>0.22</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <k3po.version>3.0.0-alpha-79</k3po.version>
     <k3po.nukleus.ext.version>0.8.2</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.11</nukleus.plugin.version>
+    <nukleus.plugin.version>0.12</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
     <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -1286,9 +1286,9 @@ final class Http2Connection
     {
         if (!headersContext.error())
         {
-            factory.httpBeginExRW.headers(b -> b.item(item -> item.representation((byte) 0)
+            factory.httpBeginExRW.headersItem(item -> item.representation((byte) 0)
                                                           .name(name, 0, name.capacity())
-                                                          .value(value, 0, value.capacity())));
+                                                          .value(value, 0, value.capacity()));
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -705,7 +705,7 @@ final class Http2Connection
     {
         ListFW<HttpHeaderFW> headers =
                 factory.headersRW.wrap(factory.errorBuf, 0, factory.errorBuf.capacity())
-                                 .item(b -> b.representation((byte)0).name(":status").value("404"))
+                                 .item(b -> b.name(":status").value("404"))
                                  .build();
 
         writeScheduler.headers(streamId, Http2Flags.END_STREAM, headers);
@@ -1119,8 +1119,7 @@ final class Http2Connection
         long targetRef = route.targetRef();
 
         httpWriter.doHttpBegin(applicationTarget, targetId, targetRef, http2Stream.correlationId,
-                hs -> headers.forEach(h -> hs.item(b -> b.representation((byte) 0)
-                                                         .name(h.name())
+                hs -> headers.forEach(h -> hs.item(b -> b.name(h.name())
                                                          .value(h.value()))));
         httpWriter.doHttpEnd(applicationTarget, targetId);
 
@@ -1286,8 +1285,7 @@ final class Http2Connection
     {
         if (!headersContext.error())
         {
-            factory.httpBeginExRW.headersItem(item -> item.representation((byte) 0)
-                                                          .name(name, 0, name.capacity())
+            factory.httpBeginExRW.headersItem(item -> item.name(name, 0, name.capacity())
                                                           .value(value, 0, value.capacity()));
         }
     }


### PR DESCRIPTION
…ange (via http2.spec).

Altered Http2Connection to use the headersItem method which is now generated on HttpBeginExFW.

Requires PR's https://github.com/reaktivity/nukleus-http2.spec/pull/30 and  https://github.com/reaktivity/nukleus-maven-plugin/pull/30