### PR TITLE
Adding access-control-allow-origin: * header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.plugin.version>0.19</nukleus.plugin.version>
     <nukleus.version>0.12</nukleus.version>
 
-    <nukleus.http2.spec.version>0.33</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
     <reaktor.version>0.32</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.plugin.version>0.19</nukleus.plugin.version>
     <nukleus.version>0.12</nukleus.version>
 
-    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>0.34</nukleus.http2.spec.version>
     <reaktor.version>0.32</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Configuration.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Configuration.java
@@ -22,6 +22,9 @@ class Http2Configuration extends Configuration
     private static final String HTTP2_SERVER_CONCURRENT_STREAMS = "nukleus.http2.server.concurrent.streams";
     private static final int HTTP2_SERVER_CONCURRENT_STREAMS_DEFAULT = 100;
 
+    private static final String HTTP2_ACCESS_CONTROL_ALLOW_ORIGIN = "nukleus.http2.server.access.control.allow.origin";
+    private static final boolean HTTP2_ACCESS_CONTROL_ALLOW_ORIGIN_DEFALUT = false;
+
     Http2Configuration(Configuration config)
     {
         super(config);
@@ -30,6 +33,11 @@ class Http2Configuration extends Configuration
     int serverConcurrentStreams()
     {
         return getInteger(HTTP2_SERVER_CONCURRENT_STREAMS, HTTP2_SERVER_CONCURRENT_STREAMS_DEFAULT);
+    }
+
+    boolean accessControlAllowOrigin()
+    {
+        return getBoolean(HTTP2_ACCESS_CONTROL_ALLOW_ORIGIN, HTTP2_ACCESS_CONTROL_ALLOW_ORIGIN_DEFALUT);
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/HpackContext.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/HpackContext.java
@@ -105,6 +105,7 @@ public class HpackContext
     public static final DirectBuffer KEEP_ALIVE = new UnsafeBuffer("keep-alive".getBytes(UTF_8));
     public static final DirectBuffer PROXY_CONNECTION = new UnsafeBuffer("proxy-connection".getBytes(UTF_8));
     public static final DirectBuffer UPGRADE = new UnsafeBuffer("upgrade".getBytes(UTF_8));
+    public static final DirectBuffer DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN = new UnsafeBuffer("*".getBytes(UTF_8));
 
     // Dynamic table. Entries are added at the end (since it is in reverse order,
     // need to calculate the index accordingly)

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/HpackLiteralHeaderFieldFW.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/types/stream/HpackLiteralHeaderFieldFW.java
@@ -254,6 +254,11 @@ public class HpackLiteralHeaderFieldFW extends Flyweight
             return this;
         }
 
+        public HpackLiteralHeaderFieldFW.Builder value(DirectBuffer valueBuffer)
+        {
+            return value(valueBuffer, 0, valueBuffer.capacity());
+        }
+
         public HpackLiteralHeaderFieldFW.Builder value(DirectBuffer valueBuffer, int offset, int length)
         {
             valueRW.string(valueBuffer, offset, length);

--- a/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/ConfigIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/ConfigIT.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.http2.internal.streams.server.rfc7540;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.reaktor.test.ReaktorRule;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+public class ConfigIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/http2/control/route")
+            .addScriptRoot("spec", "org/reaktivity/specification/http2/rfc7540/config")
+            .addScriptRoot("nukleus", "org/reaktivity/specification/nukleus/http2/streams/rfc7540/config");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final ReaktorRule reaktor = new ReaktorRule()
+            .directory("target/nukleus-itests")
+            .commandBufferCapacity(1024)
+            .responseBufferCapacity(1024)
+            .counterValuesBufferCapacity(1024)
+            .nukleus("http2"::equals)
+            .configure("nukleus.http2.server.access.control.allow.origin", "true")
+            .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+
+    @Test
+    @Specification({
+            "${route}/server/controller",
+            "${spec}/access.control.allow.origin/client",
+            "${nukleus}/access.control.allow.origin/server" })
+    public void accessControlAllowOrigin() throws Exception
+    {
+        k3po.finish();
+    }
+
+}


### PR DESCRIPTION
Adding access-control-allow-origin: * header. It is enabled via configuration. 
https://github.com/reaktivity/nukleus-http2.java/issues/77