### PR TITLE
null payload is excluded from the flow control calculations

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -1614,7 +1614,7 @@ final class Http2Connection
                 correlation.pushHandler.accept(promisedStreamId, dataEx.headers());
             }
         }
-        if (payload != null && payload.sizeof() >= 0)
+        if (payload != null)
         {
             Http2Stream stream = http2Streams.get(correlation.http2StreamId);
             if (stream != null)

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -1614,7 +1614,7 @@ final class Http2Connection
                 correlation.pushHandler.accept(promisedStreamId, dataEx.headers());
             }
         }
-        if (payload != null && payload.sizeof() > 0)
+        if (payload != null && payload.sizeof() >= 0)
         {
             Http2Stream stream = http2Streams.get(correlation.http2StreamId);
             if (stream != null)


### PR DESCRIPTION
null payload is excluded from the flow control calculations (but zero-length
DATA frames are not). If push promise comes in null DATA frames, they are
excluded from flow control