### PR TITLE
Removing the restriction that slot capacity needs to be more than the…

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
@@ -118,7 +118,11 @@ class Http2Stream
     void onData()
     {
         boolean written = httpWriteScheduler.onData(factory.http2DataRO);
-        assert written;
+        if (!written)
+        {
+            connection.writeScheduler.rst(http2StreamId, Http2ErrorCode.ENHANCE_YOUR_CALM);
+            onAbort();
+        }
     }
 
     void onAbort()

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriteScheduler.java
@@ -80,8 +80,8 @@ class HttpWriteScheduler
                 if (dst != null)
                 {
                     boolean written = targetBuffer.write(dst, http2DataRO.buffer(), http2DataRO.dataOffset() + toHttp, toSlab);
-                    assert written;
-                    assert totalRead == totalWritten + targetBuffer.size();
+//                    assert written;
+//                    assert totalRead == totalWritten + targetBuffer.size();
 
                     return written;
                 }
@@ -103,8 +103,8 @@ class HttpWriteScheduler
             MutableDirectBuffer buffer = acquire();
             boolean written = targetBuffer.write(buffer, http2DataRO.buffer(), http2DataRO.dataOffset(),
                     http2DataRO.dataLength());
-            assert written;
-            assert totalRead == totalWritten + targetBuffer.size();
+//            assert written;
+//            assert totalRead == totalWritten + targetBuffer.size();
 
             return written;
         }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
@@ -137,12 +137,6 @@ public final class ServerStreamFactory implements StreamFactory
         this.router = requireNonNull(router);
         this.writeBuffer = requireNonNull(writeBuffer);
         this.bufferPool = requireNonNull(bufferPool);
-        if (bufferPool.slotCapacity() < Settings.DEFAULT_INITIAL_WINDOW_SIZE)
-        {
-            String msg = String.format("Need larger slot, current slot=%d window=%d",
-                    bufferPool.slotCapacity(), Settings.DEFAULT_INITIAL_WINDOW_SIZE);
-            throw new IllegalArgumentException(msg);
-        }
         this.framePool = bufferPool.duplicate();
         this.headersPool = bufferPool.duplicate();
         this.httpWriterPool = bufferPool.duplicate();


### PR DESCRIPTION
Removing the restriction that slot capacity needs to be more than the flow window
on the request side. It allows more number of connections for the same amount
of memory.

This also introduces an issue. A client may send 64k for initial request(and that will be
reset by the h2 nukleus). This will be fixed later.