### PR TITLE
Propagating trace info on request and response frames

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -175,7 +175,7 @@ final class Http2Connection
     void processUnexpected(
             long streamId)
     {
-        factory.doReset(networkConsumer, streamId);
+        factory.doReset(networkConsumer, streamId, 0);
         cleanConnection();
     }
 
@@ -223,7 +223,7 @@ final class Http2Connection
 
     void handleReset(ResetFW reset)
     {
-        http2Streams.forEach((i, s) -> s.onReset());
+        http2Streams.forEach((i, s) -> s.onReset(reset.trace()));
         cleanConnection();
     }
 
@@ -375,7 +375,7 @@ final class Http2Connection
             if (frameSlotIndex == NO_SLOT)
             {
                 // all slots are in use, just reset the connection
-                factory.doReset(networkConsumer, sourceId);
+                factory.doReset(networkConsumer, sourceId, 0);
                 handleAbort(0);
                 http2FrameAvailable = false;
                 return false;
@@ -404,7 +404,7 @@ final class Http2Connection
             if (headersSlotIndex == NO_SLOT)
             {
                 // all slots are in use, just reset the connection
-                factory.doReset(networkConsumer, sourceId);
+                factory.doReset(networkConsumer, sourceId, 0);
                 handleAbort(0);
                 return false;
             }
@@ -741,7 +741,7 @@ final class Http2Connection
         }
         else
         {
-            stream.onReset();
+            stream.onReset(0);
             closeStream(stream);
         }
     }
@@ -1599,7 +1599,7 @@ final class Http2Connection
         Http2Stream stream = http2Streams.get(correlation.http2StreamId);
         if (stream == null)
         {
-            factory.doReset(applicationReplyThrottle, applicationReplyId);
+            factory.doReset(applicationReplyThrottle, applicationReplyId, 0);
         }
         else
         {
@@ -1675,7 +1675,7 @@ final class Http2Connection
 
     void doRstByUs(Http2Stream stream, Http2ErrorCode errorCode)
     {
-        stream.onReset();
+        stream.onReset(0);
         writeScheduler.rst(stream.http2StreamId, errorCode);
         closeStream(stream);
     }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -215,9 +215,9 @@ final class Http2Connection
         traceId = 0;
     }
 
-    void handleAbort()
+    void handleAbort(long traceId)
     {
-        http2Streams.forEach((i, s) -> s.onAbort());
+        http2Streams.forEach((i, s) -> s.onAbort(traceId));
         cleanConnection();
     }
 
@@ -376,7 +376,7 @@ final class Http2Connection
             {
                 // all slots are in use, just reset the connection
                 factory.doReset(networkConsumer, sourceId);
-                handleAbort();
+                handleAbort(0);
                 http2FrameAvailable = false;
                 return false;
             }
@@ -405,7 +405,7 @@ final class Http2Connection
             {
                 // all slots are in use, just reset the connection
                 factory.doReset(networkConsumer, sourceId);
-                handleAbort();
+                handleAbort(0);
                 return false;
             }
         }
@@ -1630,7 +1630,7 @@ final class Http2Connection
             {
                 int promisedStreamId = correlation.promisedStreamIds.getAsInt();
                 Http2DataExFW dataEx = extension.get(factory.dataExRO::wrap);
-                writeScheduler.pushPromise(pushStreamId, promisedStreamId, dataEx.headers());
+                writeScheduler.pushPromise(traceId, pushStreamId, promisedStreamId, dataEx.headers());
                 correlation.pushHandler.accept(promisedStreamId, dataEx.headers());
             }
         }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -699,7 +699,7 @@ final class Http2Connection
         stream.contentLength = headersContext.contentLength;
 
         HttpBeginExFW beginEx = factory.httpBeginExRW.build();
-        httpWriter.doHttpBegin(applicationTarget, stream.targetId, targetRef, stream.correlationId,
+        httpWriter.doHttpBegin(applicationTarget, stream.targetId, traceId, targetRef, stream.correlationId,
                 beginEx.buffer(), beginEx.offset(), beginEx.sizeof());
         router.setThrottle(applicationName, stream.targetId, stream::onThrottle);
 
@@ -1147,7 +1147,8 @@ final class Http2Connection
         long targetId = http2Stream.targetId;
         long targetRef = route.targetRef();
 
-        httpWriter.doHttpBegin(applicationTarget, targetId, targetRef, http2Stream.correlationId,
+        httpWriter.doHttpBegin(applicationTarget, targetId, factory.supplyTrace.getAsLong(),
+                targetRef, http2Stream.correlationId,
                 hs -> headers.forEach(h -> hs.item(b -> b.name(h.name())
                                                          .value(h.value()))));
         router.setThrottle(applicationName, targetId, http2Stream::onThrottle);

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
@@ -94,7 +94,7 @@ class Http2Stream
         // more request data to be sent, so send ABORT
         if (state != Http2Connection.State.HALF_CLOSED_REMOTE)
         {
-            httpWriteScheduler.doAbort();
+            httpWriteScheduler.doAbort(0);
         }
 
         connection.writeScheduler.rst(http2StreamId, Http2ErrorCode.CONNECT_ERROR);
@@ -121,16 +121,16 @@ class Http2Stream
         if (!written)
         {
             connection.writeScheduler.rst(http2StreamId, Http2ErrorCode.ENHANCE_YOUR_CALM);
-            onAbort();
+            onAbort(0);
         }
     }
 
-    void onAbort()
+    void onAbort(long traceId)
     {
         // more request data to be sent, so send ABORT
         if (state != Http2Connection.State.HALF_CLOSED_REMOTE)
         {
-            httpWriteScheduler.doAbort();
+            httpWriteScheduler.doAbort(traceId);
         }
 
         // reset the response stream
@@ -147,7 +147,7 @@ class Http2Stream
         // more request data to be sent, so send ABORT
         if (state != Http2Connection.State.HALF_CLOSED_REMOTE)
         {
-            httpWriteScheduler.doAbort();
+            httpWriteScheduler.doAbort(0);
         }
 
         // reset the response stream
@@ -164,7 +164,7 @@ class Http2Stream
         // more request data to be sent, so send ABORT
         if (state != Http2Connection.State.HALF_CLOSED_REMOTE)
         {
-            httpWriteScheduler.doAbort();
+            httpWriteScheduler.doAbort(0);
         }
 
         if (applicationReplyThrottle != null)

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
@@ -83,9 +83,9 @@ class Http2Stream
         return http2StreamId%2 == 1;
     }
 
-    void onHttpEnd()
+    void onHttpEnd(long traceId)
     {
-        connection.writeScheduler.dataEos(http2StreamId);
+        connection.writeScheduler.dataEos(traceId, http2StreamId);
         applicationReplyThrottle = null;
     }
 
@@ -115,9 +115,9 @@ class Http2Stream
         connection.closeStream(this);
     }
 
-    void onData()
+    void onData(long traceId)
     {
-        boolean written = httpWriteScheduler.onData(factory.http2DataRO);
+        boolean written = httpWriteScheduler.onData(traceId, factory.http2DataRO);
         if (!written)
         {
             connection.writeScheduler.rst(http2StreamId, Http2ErrorCode.ENHANCE_YOUR_CALM);

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Stream.java
@@ -107,7 +107,7 @@ class Http2Stream
         // reset the response stream
         if (applicationReplyThrottle != null)
         {
-            factory.doReset(applicationReplyThrottle, applicationReplyId);
+            factory.doReset(applicationReplyThrottle, applicationReplyId, 0);
         }
 
         connection.writeScheduler.rst(http2StreamId, Http2ErrorCode.CONNECT_ERROR);
@@ -136,13 +136,13 @@ class Http2Stream
         // reset the response stream
         if (applicationReplyThrottle != null)
         {
-            factory.doReset(applicationReplyThrottle, applicationReplyId);
+            factory.doReset(applicationReplyThrottle, applicationReplyId, 0);
         }
 
         close();
     }
 
-    void onReset()
+    void onReset(long networkReplyTraceId)
     {
         // more request data to be sent, so send ABORT
         if (state != Http2Connection.State.HALF_CLOSED_REMOTE)
@@ -153,7 +153,7 @@ class Http2Stream
         // reset the response stream
         if (applicationReplyThrottle != null)
         {
-            factory.doReset(applicationReplyThrottle, applicationReplyId);
+            factory.doReset(applicationReplyThrottle, applicationReplyId, networkReplyTraceId);
         }
 
         close();
@@ -169,7 +169,7 @@ class Http2Stream
 
         if (applicationReplyThrottle != null)
         {
-            factory.doReset(applicationReplyThrottle, applicationReplyId);
+            factory.doReset(applicationReplyThrottle, applicationReplyId, 0);
         }
 
         close();

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2WriteScheduler.java
@@ -64,7 +64,7 @@ public class Http2WriteScheduler implements WriteScheduler
     @Override
     public boolean windowUpdate(int streamId, int update)
     {
-        long traceId = 0;
+        long traceId = connection.factory.supplyTrace.getAsLong();
         int length = 4;                     // 4 window size increment
         int sizeof = length + 9;            // +9 for HTTP2 framing
         Http2FrameType type = WINDOW_UPDATE;
@@ -88,7 +88,7 @@ public class Http2WriteScheduler implements WriteScheduler
     {
         assert length == 8;
 
-        long traceId = 0;
+        long traceId = connection.factory.supplyTrace.getAsLong();
         int streamId = 0;
         int sizeof = 9 + length;             // +9 for HTTP2 framing, +8 for a ping
         Http2FrameType type = PING;
@@ -114,7 +114,7 @@ public class Http2WriteScheduler implements WriteScheduler
     public boolean goaway(int lastStreamId, Http2ErrorCode errorCode)
     {
         int streamId = 0;
-        long traceId = 0;
+        long traceId = connection.factory.supplyTrace.getAsLong();
         int length = 8;                     // 8 for goaway payload
         int sizeof = length + 9;            // +9 for HTTP2 framing
         Flyweight.Builder.Visitor goaway = http2Writer.visitGoaway(lastStreamId, errorCode);
@@ -136,7 +136,7 @@ public class Http2WriteScheduler implements WriteScheduler
     @Override
     public boolean rst(int streamId, Http2ErrorCode errorCode)
     {
-        long traceId = 0;
+        long traceId = connection.factory.supplyTrace.getAsLong();
         int length = 4;                     // 4 for RST_STREAM payload
         int sizeof = length + 9;            // +9 for HTTP2 framing
         Flyweight.Builder.Visitor visitor = http2Writer.visitRst(streamId, errorCode);
@@ -159,7 +159,7 @@ public class Http2WriteScheduler implements WriteScheduler
     @Override
     public boolean settings(int maxConcurrentStreams, int initialWindowSize)
     {
-        long traceId = 0;
+        long traceId = connection.factory.supplyTrace.getAsLong();
         int streamId = 0;
         int length = 6;                     // 6 for a setting
         int sizeof = length + 9;            // +9 for HTTP2 framing
@@ -182,7 +182,7 @@ public class Http2WriteScheduler implements WriteScheduler
     @Override
     public boolean settingsAck()
     {
-        long traceId = 0;
+        long traceId = connection.factory.supplyTrace.getAsLong();
         int streamId = 0;
         int length = 0;
         int sizeof = length + 9;                 // +9 for HTTP2 framing
@@ -237,9 +237,8 @@ public class Http2WriteScheduler implements WriteScheduler
     }
 
     @Override
-    public boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers)
+    public boolean pushPromise(long traceId, int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers)
     {
-        long traceId = 0;
         MutableDirectBuffer copy = null;
         int length = headersLength(headers);            // estimate only
         int sizeof = 9 + 4 + length;                    // +9 for HTTP2 framing, +4 for promised stream id

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Writer.java
@@ -64,6 +64,7 @@ class Http2Writer
     void doData(
             MessageConsumer target,
             long targetId,
+            long traceId,
             int padding,
             MutableDirectBuffer payload,
             int offset,
@@ -74,6 +75,7 @@ class Http2Writer
 
         DataFW data = dataRW.wrap(payload, offset - DataFW.FIELD_OFFSET_PAYLOAD, offset + length)
                             .streamId(targetId)
+                            .trace(traceId)
                             .groupId(0)
                             .padding(padding)
                             .payload(p -> p.set((b, o, l) -> length))

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriteScheduler.java
@@ -41,6 +41,7 @@ class HttpWriteScheduler
 
     private int totalRead;
     private int totalWritten;
+    private long traceId;
 
     HttpWriteScheduler(BufferPool httpWriterPool, MessageConsumer applicationTarget, HttpWriter target, long targetId,
                        Http2Stream stream)
@@ -56,8 +57,15 @@ class HttpWriteScheduler
      * @return true if the data is written or stored
      *         false if there are no slots or no space in the buffer
      */
-    boolean onData(Http2DataFW http2DataRO)
+    boolean onData(long traceId, Http2DataFW http2DataRO)
     {
+        // keep traceId of the only first data frame and we don't write traceId
+        // for subsequent data frames until the buffer is drained. This ok since
+        // we don't expect data to be buffered (except for initial request)
+        if (this.traceId == 0 && targetBuffer == null)
+        {
+            this.traceId = traceId;
+        }
         totalRead += http2DataRO.dataLength();
         end = http2DataRO.endStream();
 
@@ -92,7 +100,7 @@ class HttpWriteScheduler
             if (end && !endSent)
             {
                 endSent = true;
-                target.doHttpEnd(applicationTarget, targetId);
+                target.doHttpEnd(applicationTarget, targetId, traceId);
             }
 
             return true;
@@ -135,7 +143,7 @@ class HttpWriteScheduler
                 if (end && !endSent)
                 {
                     endSent = true;
-                    target.doHttpEnd(applicationTarget, targetId);
+                    target.doHttpEnd(applicationTarget, targetId, traceId);
                 }
 
                 release();
@@ -165,8 +173,9 @@ class HttpWriteScheduler
         assert length <= 65535;
 
         applicationBudget -= length + applicationPadding;
-        target.doHttpData(applicationTarget, targetId, applicationPadding, buffer, offset, length);
+        target.doHttpData(applicationTarget, targetId, traceId, applicationPadding, buffer, offset, length);
         totalWritten += length;
+        traceId = 0;
     }
 
     void onReset()

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriteScheduler.java
@@ -183,9 +183,9 @@ class HttpWriteScheduler
         release();
     }
 
-    void doAbort()
+    void doAbort(long traceId)
     {
-        target.doHttpAbort(applicationTarget, targetId);
+        target.doHttpAbort(applicationTarget, targetId, traceId);
         release();
     }
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
@@ -91,6 +91,7 @@ class HttpWriter
     void doHttpData(
             MessageConsumer target,
             long targetId,
+            long traceId,
             int padding,
             DirectBuffer payload,
             int offset,
@@ -100,6 +101,7 @@ class HttpWriter
 
         DataFW data = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                             .streamId(targetId)
+                            .trace(traceId)
                             .groupId(0)
                             .padding(padding)
                             .payload(p -> p.set(payload, offset, length))
@@ -110,10 +112,12 @@ class HttpWriter
 
     void doHttpEnd(
             MessageConsumer target,
-            long targetId)
+            long targetId,
+            long traceId)
     {
         EndFW end = endRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                          .streamId(targetId)
+                         .trace(traceId)
                          .extension(e -> e.reset())
                          .build();
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
@@ -126,10 +126,12 @@ class HttpWriter
 
     void doHttpAbort(
             final MessageConsumer target,
-            final long targetId)
+            final long targetId,
+            final long traceId)
     {
         final AbortFW abort = abortRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                                      .streamId(targetId)
+                                     .trace(traceId)
                                      .extension(e -> e.reset())
                                      .build();
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/HttpWriter.java
@@ -53,6 +53,7 @@ class HttpWriter
     void doHttpBegin(
             MessageConsumer target,
             long targetId,
+            long traceId,
             long targetRef,
             long correlationId,
             DirectBuffer extBuffer,
@@ -61,6 +62,7 @@ class HttpWriter
     {
         BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                                .streamId(targetId)
+                               .trace(traceId)
                                .source(SOURCE_NAME_BUFFER, 0, SOURCE_NAME_BUFFER.capacity())
                                .sourceRef(targetRef)
                                .correlationId(correlationId)
@@ -73,12 +75,14 @@ class HttpWriter
     void doHttpBegin(
             MessageConsumer target,
             long targetId,
+            long traceId,
             long targetRef,
             long correlationId,
             Consumer<ListFW.Builder<HttpHeaderFW.Builder, HttpHeaderFW>> mutator)
     {
         BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                                .streamId(targetId)
+                               .trace(traceId)
                                .source(SOURCE_NAME_BUFFER, 0, SOURCE_NAME_BUFFER.capacity())
                                .sourceRef(targetRef)
                                .correlationId(correlationId)

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
@@ -531,6 +531,7 @@ public final class ServerStreamFactory implements StreamFactory
     {
         final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                                      .streamId(targetId)
+                                     .trace(traceId)
                                      .source("http2")
                                      .sourceRef(targetRef)
                                      .correlationId(correlationId)

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
@@ -316,7 +316,7 @@ public final class ServerStreamFactory implements StreamFactory
             doWindow(networkThrottle, networkId, initialWindow, 0, 0);
             window = initialWindow;
 
-            doBegin(networkReply, networkReplyId, 0L, networkCorrelationId);
+            doBegin(networkReply, networkReplyId, supplyTrace.getAsLong(), 0L, networkCorrelationId);
             router.setThrottle(networkReplyName, networkReplyId, this::handleThrottle);
 
             this.streamState = this::afterBegin;
@@ -525,6 +525,7 @@ public final class ServerStreamFactory implements StreamFactory
     private void doBegin(
             final MessageConsumer target,
             final long targetId,
+            final long traceId,
             final long targetRef,
             final long correlationId)
     {

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
@@ -107,6 +107,7 @@ public final class ServerStreamFactory implements StreamFactory
     final BufferPool httpWriterPool;
     final BufferPool http2ReplyPool;
     final LongSupplier supplyStreamId;
+    final LongSupplier supplyTrace;
     final LongSupplier supplyCorrelationId;
     final HttpWriter httpWriter;
     final Http2Writer http2Writer;
@@ -130,6 +131,7 @@ public final class ServerStreamFactory implements StreamFactory
             LongSupplier supplyCorrelationId,
             Long2ObjectHashMap<Correlation> correlations,
             LongSupplier supplyGroupId,
+            LongSupplier supplyTrace,
             LongFunction<IntUnaryOperator> groupBudgetClaimer,
             LongFunction<IntUnaryOperator> groupBudgetReleaser)
     {
@@ -145,6 +147,7 @@ public final class ServerStreamFactory implements StreamFactory
         this.supplyCorrelationId = requireNonNull(supplyCorrelationId);
         this.correlations = requireNonNull(correlations);
         this.supplyGroupId = requireNonNull(supplyGroupId);
+        this.supplyTrace = requireNonNull(supplyTrace);
         this.groupBudgetClaimer = requireNonNull(groupBudgetClaimer);
         this.groupBudgetReleaser = requireNonNull(groupBudgetReleaser);
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
@@ -362,7 +362,7 @@ public final class ServerStreamFactory implements StreamFactory
             doAbort(networkReply, networkReplyId);
 
             // aborts http request stream, resets http response stream
-            http2Connection.handleAbort();
+            http2Connection.handleAbort(abort.trace());
         }
 
         private void handleThrottle(

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactory.java
@@ -273,7 +273,7 @@ public final class ServerStreamFactory implements StreamFactory
             }
             else
             {
-                doReset(networkThrottle, networkId);
+                doReset(networkThrottle, networkId, 0);
             }
         }
 
@@ -298,7 +298,7 @@ public final class ServerStreamFactory implements StreamFactory
                     handleAbort(abort);
                     break;
                 default:
-                    doReset(networkThrottle, networkId);
+                    doReset(networkThrottle, networkId, 0);
                     break;
             }
         }
@@ -331,7 +331,7 @@ public final class ServerStreamFactory implements StreamFactory
             window -= dataRO.length() + dataRO.padding();
             if (window < 0)
             {
-                doReset(networkThrottle, networkId);
+                doReset(networkThrottle, networkId, 0);
                 //http2Connection.handleReset();
             }
             else
@@ -406,7 +406,7 @@ public final class ServerStreamFactory implements StreamFactory
         {
             http2Connection.handleReset(reset);
 
-            doReset(networkThrottle, networkId);
+            doReset(networkThrottle, networkId, 0);
         }
     }
 
@@ -452,7 +452,7 @@ public final class ServerStreamFactory implements StreamFactory
             }
             else
             {
-                doReset(applicationReplyThrottle, applicationReplyId);
+                doReset(applicationReplyThrottle, applicationReplyId, 0);
             }
         }
 
@@ -477,7 +477,7 @@ public final class ServerStreamFactory implements StreamFactory
                     handleAbort(abort);
                     break;
                 default:
-                    doReset(applicationReplyThrottle, applicationReplyId);
+                    doReset(applicationReplyThrottle, applicationReplyId, 0);
                     break;
             }
         }
@@ -498,7 +498,7 @@ public final class ServerStreamFactory implements StreamFactory
             }
             else
             {
-                doReset(applicationReplyThrottle, applicationReplyId);
+                doReset(applicationReplyThrottle, applicationReplyId, 0);
             }
         }
 
@@ -570,10 +570,12 @@ public final class ServerStreamFactory implements StreamFactory
 
     void doReset(
             final MessageConsumer throttle,
-            final long throttleId)
+            final long throttleId,
+            final long traceId)
     {
         final ResetFW reset = resetRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                                      .streamId(throttleId)
+                                     .trace(traceId)
                                      .build();
 
         throttle.accept(reset.typeId(), reset.buffer(), reset.offset(), reset.sizeof());

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/ServerStreamFactoryBuilder.java
@@ -35,6 +35,7 @@ public final class ServerStreamFactoryBuilder implements StreamFactoryBuilder
     private RouteManager router;
     private MutableDirectBuffer writeBuffer;
     private LongSupplier supplyStreamId;
+    private LongSupplier supplyTrace;
     private LongSupplier supplyGroupId;
     private LongSupplier supplyCorrelationId;
     private Supplier<BufferPool> supplyBufferPool;
@@ -81,6 +82,14 @@ public final class ServerStreamFactoryBuilder implements StreamFactoryBuilder
     }
 
     @Override
+    public StreamFactoryBuilder setTraceSupplier(LongSupplier supplyTrace)
+    {
+        this.supplyTrace = supplyTrace;
+        return this;
+    }
+
+
+    @Override
     public StreamFactoryBuilder setGroupBudgetClaimer(LongFunction<IntUnaryOperator> groupBudgetClaimer)
     {
         this.groupBudgetClaimer = groupBudgetClaimer;
@@ -116,6 +125,6 @@ public final class ServerStreamFactoryBuilder implements StreamFactoryBuilder
         final BufferPool bufferPool = supplyBufferPool.get();
 
         return new ServerStreamFactory(config, router, writeBuffer, bufferPool, supplyStreamId, supplyCorrelationId,
-                correlations, supplyGroupId, groupBudgetClaimer, groupBudgetReleaser);
+                correlations, supplyGroupId, supplyTrace, groupBudgetClaimer, groupBudgetReleaser);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
@@ -48,7 +48,7 @@ public interface WriteScheduler
 
     boolean headers(long traceId, int streamId, byte flags, ListFW<HttpHeaderFW> headers);
 
-    boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers);
+    boolean pushPromise(long traceId, int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers);
 
     boolean data(long traceId, int streamId, DirectBuffer buffer, int offset, int length);
 

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/WriteScheduler.java
@@ -46,13 +46,13 @@ public interface WriteScheduler
 
     boolean settingsAck();
 
-    boolean headers(int streamId, byte flags, ListFW<HttpHeaderFW> headers);
+    boolean headers(long traceId, int streamId, byte flags, ListFW<HttpHeaderFW> headers);
 
     boolean pushPromise(int streamId, int promisedStreamId, ListFW<HttpHeaderFW> headers);
 
-    boolean data(int streamId, DirectBuffer buffer, int offset, int length);
+    boolean data(long traceId, int streamId, DirectBuffer buffer, int offset, int length);
 
-    boolean dataEos(int streamId);
+    boolean dataEos(long traceId, int streamId);
 
     void doEnd();
 


### PR DESCRIPTION
* On the request side, some frames may not have trace info (if the data
  is buffered and buffered data doesn't go out in one frame)
* On the response side, only one stream's trace info is added when
  the data frame is assembled from multiple streams
* for protocol frames (like SETTINGS etc), trace info is not added