### PR TITLE
Ignoring RST_STREAM once the stream is already in closed state

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.http2.spec.version>0.52</nukleus.http2.spec.version>
+    <nukleus.http2.spec.version>develop-SNAPSHOT</nukleus.http2.spec.version>
     <nukleus.tcp.version>0.56</nukleus.tcp.version>
     <reaktor.version>0.59</reaktor.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
+++ b/src/main/java/org/reaktivity/nukleus/http2/internal/Http2Connection.java
@@ -456,6 +456,9 @@ final class Http2Connection
                 factory.counters.priorityFramesRead.getAsLong();
                 onStreamPriority(stream, http2Frame);
                 break;
+            case RST_STREAM:
+                onStreamRst(stream, http2Frame, true);
+                break;
             case UNKNOWN:
                 break;
             default:
@@ -481,7 +484,7 @@ final class Http2Connection
                 break;
             case RST_STREAM:
                 factory.counters.resetStreamFramesRead.getAsLong();
-                onStreamRst(stream, http2Frame);
+                onStreamRst(stream, http2Frame, false);
                 break;
             case WINDOW_UPDATE:
                 factory.counters.windowUpdateFramesRead.getAsLong();
@@ -866,7 +869,8 @@ final class Http2Connection
 
     private void onStreamRst(
         Http2Stream stream,
-        Http2FrameFW http2Frame)
+        Http2FrameFW http2Frame,
+        boolean ignore)
     {
         Http2RstStreamFW http2RstStream =
                 factory.http2RstStreamRO.tryWrap(http2Frame.buffer(), http2Frame.offset(), http2Frame.limit());
@@ -876,8 +880,11 @@ final class Http2Connection
             return;
         }
 
-        stream.onReset(0);
-        closeStream(stream);
+        if (!ignore)
+        {
+            stream.onReset(0);
+            closeStream(stream);
+        }
     }
 
     private void applySetting(

--- a/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/ConnectionManagementIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http2/internal/streams/server/rfc7540/ConnectionManagementIT.java
@@ -140,6 +140,16 @@ public class ConnectionManagementIT
     @Test
     @Specification({
             "${route}/server/controller",
+            "${spec}/ignore.rst.stream/client",
+            "${nukleus}/ignore.rst.stream/server" })
+    public void ignoreRsttStream() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+            "${route}/server/controller",
             "${spec}/client.sent.read.abort.on.open.request/client",
             "${nukleus}/client.sent.read.abort.on.open.request/server"
     })


### PR DESCRIPTION
Ignoring RST_STREAM once the stream is already in closed state (due to
first RST_STREAM)